### PR TITLE
Feature: Option to use Strings rather than Buffers for Payload & Metadata

### DIFF
--- a/src/event_repository.rs
+++ b/src/event_repository.rs
@@ -117,10 +117,10 @@ impl DynamoEventRepository {
             let sequence = AttributeValue::N(String::from(&event.sequence.to_string()));
             let event_version = AttributeValue::S(String::from(&event.event_version));
             let event_type = AttributeValue::S(String::from(&event.event_type));
-            let payload_blob = serde_json::to_vec(&event.payload).unwrap();
-            let payload = AttributeValue::B(Blob::new(payload_blob));
-            let metadata_blob = serde_json::to_vec(&event.metadata).unwrap();
-            let metadata = AttributeValue::B(Blob::new(metadata_blob));
+            let payload_json = serde_json::to_string(&event.payload).unwrap();
+            let payload = AttributeValue::S(payload_json);
+            let metadata_json = serde_json::to_string(&event.metadata).unwrap();
+            let metadata = AttributeValue::S(metadata_json);
 
             let put = Put::builder()
                 .table_name(table_name)
@@ -202,8 +202,8 @@ impl DynamoEventRepository {
         let aggregate_id = AttributeValue::S(aggregate_id);
         let current_sequence = AttributeValue::N(current_sequence.to_string());
         let current_snapshot = AttributeValue::N(current_snapshot.to_string());
-        let payload_blob = serde_json::to_vec(&aggregate_payload).unwrap();
-        let payload = AttributeValue::B(Blob::new(payload_blob));
+        let payload_json = serde_json::to_string(&aggregate_payload).unwrap();
+        let payload = AttributeValue::S(payload_json);
         let expected_snapshot = AttributeValue::N(expected_snapshot.to_string());
         transactions.push(TransactWriteItem::builder()
             .put(Put::builder()

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -46,9 +46,12 @@ pub(crate) fn att_as_value(
     let attribute = require_attribute(values, attribute_name)?;
     match attribute.as_b() {
         Ok(payload_blob) => Ok(serde_json::from_slice(payload_blob.as_ref())?),
-        Err(_) => Err(DynamoAggregateError::MissingAttribute(
-            attribute_name.to_string(),
-        )),
+        Err(_) => match attribute.as_s() {
+            Ok(payload_string) => Ok(serde_json::from_str(&payload_string)?),
+            Err(_) => Err(DynamoAggregateError::MissingAttribute(
+                attribute_name.to_string(),
+            )),
+        },
     }
 }
 


### PR DESCRIPTION
Hi! Thanks for a great project!

I like to use Strings with DynamoDB because it makes it easier to debug (and easier to cheat if I need to edit an event in-place to fix an issue). This provides an option to do so.

### To-Do

- [ ] Update `att_as_value` to accept a `use_strings` boolean argument so that it doesn't always fail first with `.as_b()` and have to fall back to `.as_s()`.